### PR TITLE
Fix 500 error when the word not found

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -175,7 +175,6 @@ export default async () => {
 
     sentry: {
       dsn: "https://1588b1ae11f340479b57e3913b92d72f@o287069.ingest.sentry.io/5887130",
-      disableServerSide: true,
       config: {
         environment: process.env.SERVER_ENV || "local",
       },

--- a/store/index.js
+++ b/store/index.js
@@ -13,7 +13,8 @@ export const useDictionaryStore = defineStore("dictionary", {
   getters: {
     searchResults: (state) => {
       if (state.wordID) {
-        return [ words.find(word => word.id === state.wordID) ];
+        const word = words.find(word => word.id === state.wordID);
+        return word ? [ word ] : [];
       } else {
         const results = words.filter(word => {
           if (state.query) {


### PR DESCRIPTION
# Step to reproduce

1. Open non-existent page e.g. https://genshin-dictionary.com/en/foo

Expected: Returns 404 error with the custom error message "This page is not found"
Actual: Returns 500 error with Nuxt's default error page