### PR TITLE
fix: show Chinese Han and Japanese Kanji in their own fonts

### DIFF
--- a/components/translation.vue
+++ b/components/translation.vue
@@ -3,7 +3,7 @@
     <span class="results__langname results__translation-item">{{ langName }}: </span>
     <div class="results__translation-item">
       <div class="results__ja">
-        <span :data-e2e="langCode">{{ word }}</span>
+        <span :lang="langCode" :data-e2e="langCode">{{ word }}</span>
         <span v-if="kana" class="results__pronunciation-ja">({{ kana }})</span>
       </div>
     </div>


### PR DESCRIPTION
Some Chinese and Japanese characters share the same character code while the fonts are slightly different.

This problem may happen in the following characters:

- 刃 ― e.g. [魔王の刃・残片 / 魔王之刃·残片](https://genshin-dictionary.com/ja/shard-of-a-foul-legacy/)
- 社 ― e.g. [浅瀬神社 / 浅濑神社](https://genshin-dictionary.com/ja/asase-shrine/)
- 海 ― e.g. [海染硨磲 / 海染砗磲](https://genshin-dictionary.com/ja/ocean-hued-clam/)
- 角 ― e.g. [黒晶の角笛 / 黑晶号角](https://genshin-dictionary.com/ja/black-crystal-horn/)
- 骨 ― e.g. [獣骨ラーメン / 兽骨拉面](https://genshin-dictionary.com/ja/tonkotsu-ramen/)

Before this commit, the Japanese translation was displayed in Chinese font when the users used Chinese UI, and the Chinese translation was displayed in Japanese font when the users used Japanese UI.

By this commit, the Japanese translation would always be displayed in Japanese font, and the Chinese translation would always be displayed in Chinese font.