### PR TITLE
Fix title & description for the words without Chinese 

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -116,8 +116,6 @@ export default async () => {
           en: {
             siteTitle: "Genshin Dictionary",
             indexTitleDesc: "an online English-Chinese-Japanese dictionary for terms in Genshin Impact",
-            wordIdTitle: "\"{en}\" is \"{zhCN}\" in Chinese",
-            wordIdDescription: "\"{en}\" is \"{zhCN}\" in Chinese and \"{ja}\" in Japanese. This website contains English, Chinese, and Japanese translations for terms in Genshin Impact.",
             aboutTitle: "About this website",
             aboutDescription: "About Genshin Dictionary. This website is an online English-Chinese-Japanese dictionary for the terms in Genshin Impact.",
             historyTitle: "Update History",
@@ -129,8 +127,6 @@ export default async () => {
           ja: {
             siteTitle: "原神 英語・中国語辞典",
             indexTitleDesc: "原神の固有名詞等の英語表記、及び中国語表記の一覧を掲載しています。",
-            wordIdTitle: "「{ja}」は英語で \"{en}\"",
-            wordIdDescription: "「{ja}」の英語表記は \"{en}\"、中国語表記は「{zhCN}」 ― このサイトはゲーム「原神」の用語の、日本語・英語・中国語の対訳を掲載しています。",
             aboutTitle: "このサイトについて",
             aboutDescription: "原神英語・中国語辞典についての説明です。このサイトは PC・スマートフォン・プレイステーション4/5用ゲーム「原神」で用いられる固有名詞等の日本語・英語・中国語対訳表です。",
             historyTitle: "更新履歴",
@@ -142,8 +138,6 @@ export default async () => {
           "zh-CN": {
             siteTitle: "原神中英日辞典",
             indexTitleDesc: "一个在线的中英日三语原神游戏用语辞典",
-            wordIdTitle: "\"{zhCN}\"的英语和日语翻译",
-            wordIdDescription: "\"{zhCN}\"的英语是\"{en}\"，日语是\"{ja}\"。", // TODO TranslationChanged
             aboutTitle: "关于本网站",
             aboutDescription: "关于原神中英日辞典。本网站是一个在线的中英日三语原神游戏用语辞典。",
             historyTitle: "更新记录",

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -115,9 +115,9 @@ export default async () => {
         messages: {
           en: {
             siteTitle: "Genshin Dictionary",
-            indexTitleDesc: "an online English-Chinese-Japanese dictionary for terms in Genshin Impact",
+            indexTitleDesc: "An online English-Chinese-Japanese dictionary of the terms in Genshin Impact",
             aboutTitle: "About this website",
-            aboutDescription: "About Genshin Dictionary. This website is an online English-Chinese-Japanese dictionary for the terms in Genshin Impact.",
+            aboutDescription: "About Genshin Dictionary. This website is an online English-Chinese-Japanese dictionary of the terms in Genshin Impact.",
             historyTitle: "Update History",
             opendataTitle: "Open Data / API (β)",
             langNameEn: "English",

--- a/pages/_wordid.vue
+++ b/pages/_wordid.vue
@@ -41,17 +41,17 @@ export default defineComponent({
     let description;
 
     if (i18n.locale === "en") {
-      title = `"${word.en}" is ` + (word.zhCN ? `"${word.zhCN}" in Chinese` : `${word.ja} in Japanese`);
+      title = `"${word.en}" is ` + (word.zhCN ? `"${word.zhCN}" in Chinese` : `${word.ja} in Japanese`) + ` | ${ i18n.t("siteTitle") }`;
       description = `"${word.en}" is `
                   + (word.zhCN ? `"${word.zhCN}" in Chinese and ` : "")
                   + `"${word.ja}" in Japanese. This website contains English, Chinese, and Japanese translations for terms in Genshin Impact.`;
     } else if (i18n.locale === "ja") {
-      title = `「${word.ja}」は英語で "${word.en}"`;
+      title = `「${word.ja}」は英語で "${word.en}" | ${ i18n.t("siteTitle") }`;
       description = `「${word.ja}」の英語表記は "${word.en}"`
                   + (word.zhCN ? `、中国語表記は「${word.zhCN}」` : "")
                   + " ― このサイトはゲーム「原神」の用語の、日本語・英語・中国語の対訳を掲載しています。";
     } else if (i18n.locale === "zh-CN") {
-      title = word.zhCN ? `"${word.zhCN}"的英语和日语翻译` : `"${word.en}"的日语翻译`;
+      title = (word.zhCN ? `"${word.zhCN}"的英语和日语翻译` : `"${word.en}"的日语翻译`) + ` | ${ i18n.t("siteTitle") }`;
       description = word.zhCN ?
         `"${word.zhCN}"的英语是"${word.en}"，日语是"${word.ja}"。` : // TODO TranslationChanged
         `"${word.en}"的日语是"${word.ja}"。`;

--- a/pages/_wordid.vue
+++ b/pages/_wordid.vue
@@ -51,7 +51,7 @@ export default defineComponent({
                   + (word.zhCN ? `、中国語表記は「${word.zhCN}」` : "")
                   + " ― このサイトはゲーム「原神」の用語の、日本語・英語・中国語の対訳を掲載しています。";
     } else if (i18n.locale === "zh-CN") {
-      title = `"${word.zhCN ?? word.en}"的英语和日语翻译`;
+      title = word.zhCN ? `"${word.zhCN}"的英语和日语翻译` : `"${word.en}"的日语翻译`;
       description = word.zhCN ?
         `"${word.zhCN}"的英语是"${word.en}"，日语是"${word.ja}"。` : // TODO TranslationChanged
         `"${word.en}"的日语是"${word.ja}"。`;

--- a/pages/_wordid.vue
+++ b/pages/_wordid.vue
@@ -34,8 +34,24 @@ export default defineComponent({
       return;
     }
 
-    const title = `${ i18n.t("wordIdTitle", { ja: word.ja, en: word.en, zhCN: word.zhCN }) } | ${ i18n.t("siteTitle") }`;
-    const description = i18n.t("wordIdDescription", { ja: word.ja, en: word.en, zhCN: word.zhCN });
+    //
+    // title & description
+    //
+    let title;
+    let description;
+
+    if (i18n.locale === "en") {
+      title = `"${word.en}" is "${word.zhCN}" in Chinese`;
+      description = `"${word.en}" is "${word.zhCN}" in Chinese and "${word.ja}" in Japanese. This website contains English, Chinese, and Japanese translations for terms in Genshin Impact.`;
+    } else if (i18n.locale === "ja") {
+      title = `「${word.ja}」は英語で "${word.en}"`;
+      description = `「${word.ja}」の英語表記は "${word.en}"、中国語表記は「${word.zhCN}」 ― このサイトはゲーム「原神」の用語の、日本語・英語・中国語の対訳を掲載しています。`;
+    } else if (i18n.locale === "zh-CN") {
+      title = `"${word.zhCN}"的英语和日语翻译`;
+      description = `"${word.zhCN}"的英语是"${word.en}"，日语是"${word.ja}"。`; // TODO TranslationChanged
+    } else {
+      throw new Error(`Unexpected locale: ${i18n.locale}`);
+    }
 
     useMeta({
       title,

--- a/pages/_wordid.vue
+++ b/pages/_wordid.vue
@@ -41,14 +41,20 @@ export default defineComponent({
     let description;
 
     if (i18n.locale === "en") {
-      title = `"${word.en}" is "${word.zhCN}" in Chinese`;
-      description = `"${word.en}" is "${word.zhCN}" in Chinese and "${word.ja}" in Japanese. This website contains English, Chinese, and Japanese translations for terms in Genshin Impact.`;
+      title = `"${word.en}" is ` + (word.zhCN ? `"${word.zhCN}" in Chinese` : `${word.ja} in Japanese`);
+      description = `"${word.en}" is `
+                  + (word.zhCN ? `"${word.zhCN}" in Chinese and ` : "")
+                  + `"${word.ja}" in Japanese. This website contains English, Chinese, and Japanese translations for terms in Genshin Impact.`;
     } else if (i18n.locale === "ja") {
       title = `「${word.ja}」は英語で "${word.en}"`;
-      description = `「${word.ja}」の英語表記は "${word.en}"、中国語表記は「${word.zhCN}」 ― このサイトはゲーム「原神」の用語の、日本語・英語・中国語の対訳を掲載しています。`;
+      description = `「${word.ja}」の英語表記は "${word.en}"`
+                  + (word.zhCN ? `、中国語表記は「${word.zhCN}」` : "")
+                  + " ― このサイトはゲーム「原神」の用語の、日本語・英語・中国語の対訳を掲載しています。";
     } else if (i18n.locale === "zh-CN") {
-      title = `"${word.zhCN}"的英语和日语翻译`;
-      description = `"${word.zhCN}"的英语是"${word.en}"，日语是"${word.ja}"。`; // TODO TranslationChanged
+      title = `"${word.zhCN ?? word.en}"的英语和日语翻译`;
+      description = word.zhCN ?
+        `"${word.zhCN}"的英语是"${word.en}"，日语是"${word.ja}"。` : // TODO TranslationChanged
+        `"${word.en}"的日语是"${word.ja}"。`;
     } else {
       throw new Error(`Unexpected locale: ${i18n.locale}`);
     }


### PR DESCRIPTION
Currently, the words without Chinese translation has weird title and description on their pages. (https://genshin-dictionary.com/LOCALE/*)

English
- title: "Tulaytullah's Remembrance" is "" in Chinese | Genshin Dictionary
- description: "Tulaytullah's Remembrance" is "" in Chinese and "トゥライトゥーラの記憶" in Japanese. This website contains English, Chinese, and Japanese translations for terms in Genshin Impact.

Japanese
- title: (no problem)
- description: 「トゥライトゥーラの記憶」の英語表記は "Tulaytullah's Remembrance"、中国語表記は「」 ― このサイトはゲーム「原神」の用語の、日本語・英語・中国語の対訳を掲載しています。

Chinese
- title: ""的英语和日语翻译 | 原神中英日辞典
- description: ""的英语是"Tulaytullah's Remembrance"，日语是"トゥライトゥーラの記憶"。

This affects usability and might have a negative impact on SEO.
This PR fixes empty Chinese translations in titles and descriptions.