### PR TITLE
Disallow wrapping on language name (简体中文)

### DIFF
--- a/components/translation.vue
+++ b/components/translation.vue
@@ -75,6 +75,7 @@ if (0 < props.pinyins.length) {
   &__langname {
     font-size: 0.7em;
     width: 4.5em;
+    white-space: nowrap;
   }
 
 


### PR DESCRIPTION
Closes #86

This bug is fixed by #108 before, but it was reverted by #115. This PR applies the same fix again.