### PR TITLE
Fix broken copied URL

### DIFF
--- a/components/word-list-results.vue
+++ b/components/word-list-results.vue
@@ -171,7 +171,7 @@ onUpdated(async () => {
 //
 const localePath = useLocalePath();
 const copyLink = async (wordId, $event) => {
-  navigator.clipboard.writeText(`https://genshin-dictionary.com/${locale}/${wordId}`);
+  navigator.clipboard.writeText(`https://genshin-dictionary.com/${locale.value}/${wordId}`);
 
   const copyImg = $event.target;
   const copiedImg = copyImg.parentElement.getElementsByClassName("results__permalink--copied")[0];


### PR DESCRIPTION
Before this PR, `https://genshin-dictionary.com/[object Object]/WORDNAME` is copied when you press copy button.
This PR fixes that bug and e.g. `https://genshin-dictionary.com/ja/WORDNAME` would be copied properly.