### PR TITLE
Run `npm ci` before purging Cloudflare edge cache

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -82,7 +82,8 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: flyctl deploy --remote-only
 
-      - name: Purge Cloudflare cache
+      - name: Purge Cloudflare edge cache
         run: |
-          npm install node-fetch esno
+          npm ci --omit=dev
+          npm install esno
           npm run purge-cache


### PR DESCRIPTION
To run scripts/purge-cache.ts, .nuxt/tsconfig.json is required since it is TypeScript code.
However, it is not generated currently because `nuxt prepare` in the `postinstall` process is not executed.