### PR TITLE
Use meta tag for Google Search Console verification

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -42,6 +42,11 @@ useHead({
     { hid: "twitter:card", property: "twitter:card", content: "summary" },
     { hid: "twitter:site", property: "twitter:site", content: "@xicri_gi" },
     { hid: "twitter:creator", property: "twitter:creator", content: "@xicri_gi" },
+    {
+      hid: "google-site-verification",
+      name: "google-site-verification",
+      content: "siYv7dgV8-NP15jdAUtGC0L52osNwLDBt7HFe2LH-3s",
+    },
     ...meta,
   ],
   link: [

--- a/public/google725b556e9d5c4dd7.html
+++ b/public/google725b556e9d5c4dd7.html
@@ -1,1 +1,0 @@
-google-site-verification: google725b556e9d5c4dd7.html


### PR DESCRIPTION
A fix for #215.
HTML file does not work because Cloudflare redirect /googleNNNNNN.html to /googleNNNNNN.