### PR TITLE
ci: remove no longer used `repository_dispatch` trigger

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,9 +7,6 @@ on:
   push:
     branches:
       - main
-  repository_dispatch:
-    types:
-      - langdata-update
 
 jobs:
   test:


### PR DESCRIPTION
Related: xicri/genshin-langdata#299