### PR TITLE
Use system fonts for default font

### DIFF
--- a/assets/styles/global.scss
+++ b/assets/styles/global.scss
@@ -1,7 +1,7 @@
 @use "~/assets/styles/variables.scss" as vars;
 
 html {
-  font-family: "Noto Sans CJK JP", "Meiryo", "Hiragino Sans", sans-serif;
+  font-family: sans-serif, system-ui, -apple-system, "Noto Sans CJK";
   font-size: 16px;
   word-spacing: 1px;
   -ms-text-size-adjust: 100%;


### PR DESCRIPTION
Resolves #340.

Currently, Noto Sans CJK JP is used even for non-Japanese UIs.
To avoid being shown by wrong typographs, especially in Chinese UIs,  I'm setting the global fonts to `sans-serif, system-ui, -apple-system`.